### PR TITLE
feat: Agregar funcionalidad para eliminar usuarios en bulk

### DIFF
--- a/router/usuariosRouter.js
+++ b/router/usuariosRouter.js
@@ -368,4 +368,10 @@ apiUsuarios.delete(
   UsuariosControllers.EliminarUsuario,
 );
 
+apiUsuarios.delete(
+  "/bulk-delete-users",
+  verificarToken,
+  UsuariosControllers.DeleteUserBulk,
+);
+
 export { apiUsuarios };


### PR DESCRIPTION
# ✅Cambios realizados
- Nuevba funcion de elimacion masiva de usuarios con un limite de 600 usuairos por eliminacion con un batch o para que nmo los elimine todos de golpe, se va a hacer de 100 en 100 mejorando la eliminacion haciendo la fragmentacion por partes de cada registro
- Falta la docuemntacion del endpoint ya sea en `swagger`, `postman` o en `apidog`