### PR TITLE
perf: aumentar límites de tamaño para JSON y URL en el middleware de express

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,8 @@ setupSwagger(app);
 
 // Middleware
 app.use(cors(corsOptions));
-app.use(express.json());
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 app.use(morgan("dev"));
 app.use(helmet());
 app.use(router);


### PR DESCRIPTION
# ✅Cambios realizados
- Aumentod e la memoria para la llega de datos mas pesados por la carga masiva de ids al momento de eliminar demasiados ids, esto se hace con la finalidad de evitar que la apliacion se caiga, por usuarios que jueguen con el sistema y quieran eliminar mas de 6000 registros de usuarios o de otros modulos
> [!NOTE]
>  Esto se vera mejor reflejado en un futuro cuando se trabaje con datos y cargas mas pesadas de formatos csv o pdf